### PR TITLE
Ignore TSTypeAliasDeclaration nodes

### DIFF
--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -37,7 +37,8 @@ module.exports = function({ types: t, template }) {
 		!(parent.type === 'TSQualifiedName') &&
 		!(parent.type === 'TSTypeQuery') &&
 		!(parent.type === 'TSTypeReference') &&
-		!(parent.type === 'TSInterfaceDeclaration');
+		!(parent.type === 'TSInterfaceDeclaration') &&
+		!(parent.type === 'TSTypeAliasDeclaration');
 	}
 
 	function doesIdentifierRepresentAValidReference(path, variableBinding, rewireInformation) {


### PR DESCRIPTION
Following TypeScript code:
```ts
export type Test = { test: string; };
export function Test(test: string): Test {
     return { test };
}
```
throws
```
TypeError: Property id of TSTypeAliasDeclaration expected node to be of a type ["Identifier"] but instead got "CallExpression".
```

Due to the fact, that isRewireable() was missing check for TSTypeAliasDeclaration nodes and plugin tried to rewire assignment based on the type declaration but it actually got a function declaration (because they have the same name).