### PR TITLE
Register injected identifier for originally unnamed default exports in scope

### DIFF
--- a/src/babel-plugin-rewire.js
+++ b/src/babel-plugin-rewire.js
@@ -124,6 +124,8 @@ module.exports = function({ types: t, template }) {
 									existingClassDeclaration.decorators || []
 								)
 							);
+							scope.registerDeclaration(path);
+
 						} else {
 							exportIdentifier = existingClassDeclaration.id;
 						}
@@ -141,6 +143,8 @@ module.exports = function({ types: t, template }) {
 									existingFunctionDeclaration.async
 								)
 							);
+							scope.registerDeclaration(path);
+
 						} else if(path.parent.type === 'ExportDefaultDeclaration') {
 							exportIdentifier = existingFunctionDeclaration.id;
 						}
@@ -159,6 +163,7 @@ module.exports = function({ types: t, template }) {
 						t.variableDeclaration('let', [t.variableDeclarator(exportIdentifier, path.node.declaration)]),
 						noRewire(t.exportDefaultDeclaration(exportIdentifier))
 					]);
+					path.scope.registerDeclaration(path);
 				}
 				rewireInformation.enrichExport(exportIdentifier);
 			}


### PR DESCRIPTION
Register injected identifier for originally unnamed default exports ('_DefaultExportValue') in Babel scope tracker

This also helps clear the following console warnings when used with plugin-transform-typescript:

```
The exported identifier "_DefaultExportValue" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"_DefaultExportValue" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)"
```

Resolves issue #5 