### PR TITLE
Synchronize exports with the internal state of the module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 
 node_js:
   - node
-  - 4
-  - '0.12'
 
 script:
   - npm run test

--- a/fixtures/transformation/assignmentOperations/expected.js
+++ b/fixtures/transformation/assignmentOperations/expected.js
@@ -94,12 +94,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -107,14 +122,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -128,6 +143,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/assignmentOperations/expected.js
+++ b/fixtures/transformation/assignmentOperations/expected.js
@@ -324,6 +324,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/assignmentOperations/expected.js
+++ b/fixtures/transformation/assignmentOperations/expected.js
@@ -114,6 +114,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -174,6 +182,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -197,6 +211,82 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case 'getValue':
+			_record_export__('getValue', getValue);
+
+			return exports.getValue = _value;
+
+		case 'setValue':
+			_record_export__('setValue', setValue);
+
+			return exports.setValue = _value;
+
+		case 'assign':
+			_record_export__('assign', assign);
+
+			return exports.assign = _value;
+
+		case 'additionAssignement':
+			_record_export__('additionAssignement', additionAssignement);
+
+			return exports.additionAssignement = _value;
+
+		case 'subtractionAssignment':
+			_record_export__('subtractionAssignment', subtractionAssignment);
+
+			return exports.subtractionAssignment = _value;
+
+		case 'multiplicationAssignment':
+			_record_export__('multiplicationAssignment', multiplicationAssignment);
+
+			return exports.multiplicationAssignment = _value;
+
+		case 'divisionAssignment':
+			_record_export__('divisionAssignment', divisionAssignment);
+
+			return exports.divisionAssignment = _value;
+
+		case 'remainderAssignement':
+			_record_export__('remainderAssignement', remainderAssignement);
+
+			return exports.remainderAssignement = _value;
+
+		case 'leftShiftAssignment':
+			_record_export__('leftShiftAssignment', leftShiftAssignment);
+
+			return exports.leftShiftAssignment = _value;
+
+		case 'rightShiftAssignment':
+			_record_export__('rightShiftAssignment', rightShiftAssignment);
+
+			return exports.rightShiftAssignment = _value;
+
+		case 'unsignedRightShiftAssignment':
+			_record_export__('unsignedRightShiftAssignment', unsignedRightShiftAssignment);
+
+			return exports.unsignedRightShiftAssignment = _value;
+
+		case 'bitwiseAndAssignement':
+			_record_export__('bitwiseAndAssignement', bitwiseAndAssignement);
+
+			return exports.bitwiseAndAssignement = _value;
+
+		case 'bitwiseOrAssignement':
+			_record_export__('bitwiseOrAssignement', bitwiseOrAssignement);
+
+			return exports.bitwiseOrAssignement = _value;
+
+		case 'bitwiseXorAssignment':
+			_record_export__('bitwiseXorAssignment', bitwiseXorAssignment);
+
+			return exports.bitwiseXorAssignment = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/assignmentOperations/expected.js
+++ b/fixtures/transformation/assignmentOperations/expected.js
@@ -319,6 +319,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -101,6 +101,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -173,6 +181,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -193,6 +207,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -245,6 +245,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -250,6 +250,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/babelissue1315/expected.js
+++ b/fixtures/transformation/babelissue1315/expected.js
@@ -81,12 +81,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -94,14 +109,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -115,6 +130,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/commonJSExportOnly/expected.js
+++ b/fixtures/transformation/commonJSExportOnly/expected.js
@@ -196,6 +196,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/commonJSExportOnly/expected.js
+++ b/fixtures/transformation/commonJSExportOnly/expected.js
@@ -201,6 +201,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/commonJSExportOnly/expected.js
+++ b/fixtures/transformation/commonJSExportOnly/expected.js
@@ -44,12 +44,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -57,14 +72,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -78,6 +93,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/commonJSExportOnly/expected.js
+++ b/fixtures/transformation/commonJSExportOnly/expected.js
@@ -64,6 +64,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -124,6 +132,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -144,6 +158,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -197,6 +197,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -45,12 +45,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -58,14 +73,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -79,6 +94,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -202,6 +202,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/defaultExportWithObject/expected.js
+++ b/fixtures/transformation/defaultExportWithObject/expected.js
@@ -65,6 +65,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -125,6 +133,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -145,6 +159,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -43,12 +43,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -56,14 +71,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -77,6 +92,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -203,6 +203,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -63,6 +63,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -126,6 +134,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -146,6 +160,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/forOf/expected.js
+++ b/fixtures/transformation/forOf/expected.js
@@ -198,6 +198,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -64,6 +64,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -127,6 +135,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -147,6 +161,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -199,6 +199,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -204,6 +204,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/functionRewireScope/expected.js
+++ b/fixtures/transformation/functionRewireScope/expected.js
@@ -44,12 +44,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -57,14 +72,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -78,6 +93,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/ignoredIdentifiers/expected.js
+++ b/fixtures/transformation/ignoredIdentifiers/expected.js
@@ -203,6 +203,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/ignoredIdentifiers/expected.js
+++ b/fixtures/transformation/ignoredIdentifiers/expected.js
@@ -68,6 +68,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -131,6 +139,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -151,6 +165,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/ignoredIdentifiers/expected.js
+++ b/fixtures/transformation/ignoredIdentifiers/expected.js
@@ -208,6 +208,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/ignoredIdentifiers/expected.js
+++ b/fixtures/transformation/ignoredIdentifiers/expected.js
@@ -48,12 +48,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -61,14 +76,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -82,6 +97,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/importWithReactClass/expected.js
+++ b/fixtures/transformation/importWithReactClass/expected.js
@@ -87,6 +87,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -153,6 +161,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -173,6 +187,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/importWithReactClass/expected.js
+++ b/fixtures/transformation/importWithReactClass/expected.js
@@ -225,6 +225,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/importWithReactClass/expected.js
+++ b/fixtures/transformation/importWithReactClass/expected.js
@@ -67,12 +67,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -80,14 +95,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -101,6 +116,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/importWithReactClass/expected.js
+++ b/fixtures/transformation/importWithReactClass/expected.js
@@ -230,6 +230,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue121/expected.js
+++ b/fixtures/transformation/issue121/expected.js
@@ -49,12 +49,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -62,14 +77,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -83,6 +98,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue121/expected.js
+++ b/fixtures/transformation/issue121/expected.js
@@ -204,6 +204,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue121/expected.js
+++ b/fixtures/transformation/issue121/expected.js
@@ -209,6 +209,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue121/expected.js
+++ b/fixtures/transformation/issue121/expected.js
@@ -69,6 +69,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -132,6 +140,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -152,6 +166,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue133/expected.js
+++ b/fixtures/transformation/issue133/expected.js
@@ -42,12 +42,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -55,14 +70,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -76,6 +91,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue133/expected.js
+++ b/fixtures/transformation/issue133/expected.js
@@ -199,6 +199,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue133/expected.js
+++ b/fixtures/transformation/issue133/expected.js
@@ -62,6 +62,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -122,6 +130,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -142,6 +156,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue133/expected.js
+++ b/fixtures/transformation/issue133/expected.js
@@ -194,6 +194,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue136/expected.js
+++ b/fixtures/transformation/issue136/expected.js
@@ -56,12 +56,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -69,14 +84,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -90,6 +105,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue136/expected.js
+++ b/fixtures/transformation/issue136/expected.js
@@ -76,6 +76,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -142,6 +150,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -171,6 +185,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue136/expected.js
+++ b/fixtures/transformation/issue136/expected.js
@@ -228,6 +228,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue136/expected.js
+++ b/fixtures/transformation/issue136/expected.js
@@ -223,6 +223,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue152/expected.js
+++ b/fixtures/transformation/issue152/expected.js
@@ -42,12 +42,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -55,14 +70,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -76,6 +91,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue152/expected.js
+++ b/fixtures/transformation/issue152/expected.js
@@ -62,6 +62,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -122,6 +130,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -142,6 +156,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case "foo":
+			_record_export__("foo", foo);
+
+			return exports.foo = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue152/expected.js
+++ b/fixtures/transformation/issue152/expected.js
@@ -199,6 +199,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue152/expected.js
+++ b/fixtures/transformation/issue152/expected.js
@@ -204,6 +204,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue155/expected.js
+++ b/fixtures/transformation/issue155/expected.js
@@ -203,6 +203,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue155/expected.js
+++ b/fixtures/transformation/issue155/expected.js
@@ -198,6 +198,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue155/expected.js
+++ b/fixtures/transformation/issue155/expected.js
@@ -66,6 +66,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -126,6 +134,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -146,6 +160,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue155/expected.js
+++ b/fixtures/transformation/issue155/expected.js
@@ -46,12 +46,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -59,14 +74,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -80,6 +95,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -359,6 +359,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -176,6 +176,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -287,6 +295,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -307,6 +321,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -364,6 +364,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/issue16/expected.js
+++ b/fixtures/transformation/issue16/expected.js
@@ -156,12 +156,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -169,14 +184,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -190,6 +205,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/issue184/expected.js
+++ b/fixtures/transformation/issue184/expected.js
@@ -45,12 +45,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -58,14 +73,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -79,6 +94,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/issue184/expected.js
+++ b/fixtures/transformation/issue184/expected.js
@@ -65,6 +65,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -128,6 +136,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -148,6 +162,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue184/expected.js
+++ b/fixtures/transformation/issue184/expected.js
@@ -200,6 +200,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/issue184/expected.js
+++ b/fixtures/transformation/issue184/expected.js
@@ -205,6 +205,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/issue69/expected.js
+++ b/fixtures/transformation/issue69/expected.js
@@ -199,6 +199,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue69/expected.js
+++ b/fixtures/transformation/issue69/expected.js
@@ -204,6 +204,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue69/expected.js
+++ b/fixtures/transformation/issue69/expected.js
@@ -64,6 +64,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -124,6 +132,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -147,6 +161,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue69/expected.js
+++ b/fixtures/transformation/issue69/expected.js
@@ -44,12 +44,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -57,14 +72,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -78,6 +93,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue71-tdz-index/expected.js
+++ b/fixtures/transformation/issue71-tdz-index/expected.js
@@ -206,6 +206,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue71-tdz-index/expected.js
+++ b/fixtures/transformation/issue71-tdz-index/expected.js
@@ -66,6 +66,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -129,6 +137,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -149,6 +163,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case 'getLogConstant':
+			_record_export__('getLogConstant', getLogConstant);
+
+			return exports.getLogConstant = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue71-tdz-index/expected.js
+++ b/fixtures/transformation/issue71-tdz-index/expected.js
@@ -46,12 +46,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -59,14 +74,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -80,6 +95,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue71-tdz-index/expected.js
+++ b/fixtures/transformation/issue71-tdz-index/expected.js
@@ -211,6 +211,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issue71-tdz/expected.js
+++ b/fixtures/transformation/issue71-tdz/expected.js
@@ -43,12 +43,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -56,14 +71,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -77,6 +92,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issue71-tdz/expected.js
+++ b/fixtures/transformation/issue71-tdz/expected.js
@@ -195,6 +195,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issue71-tdz/expected.js
+++ b/fixtures/transformation/issue71-tdz/expected.js
@@ -63,6 +63,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -123,6 +131,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -143,6 +157,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issue71-tdz/expected.js
+++ b/fixtures/transformation/issue71-tdz/expected.js
@@ -200,6 +200,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -206,6 +206,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -66,6 +66,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -129,6 +137,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -149,6 +163,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case 'requiredValidatorFunction':
+			_record_export__('requiredValidatorFunction', requiredValidatorFunction);
+
+			return exports.requiredValidatorFunction = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -46,12 +46,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -59,14 +74,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -80,6 +95,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/issuePathReplaceWith/expected.js
+++ b/fixtures/transformation/issuePathReplaceWith/expected.js
@@ -211,6 +211,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/jsxSupport/expected.js
+++ b/fixtures/transformation/jsxSupport/expected.js
@@ -200,6 +200,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/jsxSupport/expected.js
+++ b/fixtures/transformation/jsxSupport/expected.js
@@ -65,6 +65,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -128,6 +136,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -148,6 +162,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/jsxSupport/expected.js
+++ b/fixtures/transformation/jsxSupport/expected.js
@@ -205,6 +205,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/jsxSupport/expected.js
+++ b/fixtures/transformation/jsxSupport/expected.js
@@ -45,12 +45,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -58,14 +73,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -79,6 +94,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/jsxWithComponentImport/expected.js
+++ b/fixtures/transformation/jsxWithComponentImport/expected.js
@@ -53,12 +53,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -66,14 +81,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -87,6 +102,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/jsxWithComponentImport/expected.js
+++ b/fixtures/transformation/jsxWithComponentImport/expected.js
@@ -214,6 +214,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/jsxWithComponentImport/expected.js
+++ b/fixtures/transformation/jsxWithComponentImport/expected.js
@@ -73,6 +73,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -142,6 +150,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -162,6 +176,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/jsxWithComponentImport/expected.js
+++ b/fixtures/transformation/jsxWithComponentImport/expected.js
@@ -219,6 +219,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -201,6 +201,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -206,6 +206,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -64,6 +64,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -124,6 +132,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -144,6 +158,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case "namedFunction":
+			_record_export__("namedFunction", namedFunction);
+
+			return exports.namedFunction = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/namedFunctionExport/expected.js
+++ b/fixtures/transformation/namedFunctionExport/expected.js
@@ -44,12 +44,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -57,14 +72,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -78,6 +93,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/namedFunctionImport/expected.js
+++ b/fixtures/transformation/namedFunctionImport/expected.js
@@ -204,6 +204,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/namedFunctionImport/expected.js
+++ b/fixtures/transformation/namedFunctionImport/expected.js
@@ -209,6 +209,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/namedFunctionImport/expected.js
+++ b/fixtures/transformation/namedFunctionImport/expected.js
@@ -47,12 +47,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -60,14 +75,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -81,6 +96,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/namedFunctionImport/expected.js
+++ b/fixtures/transformation/namedFunctionImport/expected.js
@@ -67,6 +67,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -127,6 +135,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -147,6 +161,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case 'run':
+			_record_export__('run', run);
+
+			return exports.run = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -207,6 +207,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -202,6 +202,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -47,12 +47,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -60,14 +75,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -81,6 +96,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/namedVariableExport/expected.js
+++ b/fixtures/transformation/namedVariableExport/expected.js
@@ -67,6 +67,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -130,6 +138,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -150,6 +164,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -67,6 +67,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -127,6 +135,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -147,6 +161,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case "addOne":
+			_record_export__("addOne", addOne);
+
+			return exports.addOne = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -204,6 +204,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -209,6 +209,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
+++ b/fixtures/transformation/primitiveExportWithNamedFunctionExport/expected.js
@@ -47,12 +47,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -60,14 +75,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -81,6 +96,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/recursiveRewireCall/expected.js
+++ b/fixtures/transformation/recursiveRewireCall/expected.js
@@ -150,6 +150,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -243,6 +251,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -263,6 +277,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/recursiveRewireCall/expected.js
+++ b/fixtures/transformation/recursiveRewireCall/expected.js
@@ -130,12 +130,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -143,14 +158,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -164,6 +179,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/recursiveRewireCall/expected.js
+++ b/fixtures/transformation/recursiveRewireCall/expected.js
@@ -315,6 +315,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/recursiveRewireCall/expected.js
+++ b/fixtures/transformation/recursiveRewireCall/expected.js
@@ -320,6 +320,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -64,6 +64,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -127,6 +135,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -147,6 +161,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -199,6 +199,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -44,12 +44,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -57,14 +72,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -78,6 +93,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/requireExports/expected.js
+++ b/fixtures/transformation/requireExports/expected.js
@@ -204,6 +204,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -45,12 +45,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -58,14 +73,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -79,6 +94,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -65,6 +65,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -128,6 +136,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -148,6 +162,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -200,6 +200,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/requireMultiExports/expected.js
+++ b/fixtures/transformation/requireMultiExports/expected.js
@@ -205,6 +205,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/rewiringOfReactComponents/expected.js
+++ b/fixtures/transformation/rewiringOfReactComponents/expected.js
@@ -49,12 +49,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -62,14 +77,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -83,6 +98,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/rewiringOfReactComponents/expected.js
+++ b/fixtures/transformation/rewiringOfReactComponents/expected.js
@@ -204,6 +204,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/rewiringOfReactComponents/expected.js
+++ b/fixtures/transformation/rewiringOfReactComponents/expected.js
@@ -209,6 +209,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/rewiringOfReactComponents/expected.js
+++ b/fixtures/transformation/rewiringOfReactComponents/expected.js
@@ -69,6 +69,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -132,6 +140,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -152,6 +166,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
+++ b/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
@@ -247,6 +247,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
+++ b/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
@@ -101,6 +101,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -170,6 +178,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -190,6 +204,17 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case 'another':
+			_record_export__('another', another);
+
+			return exports.another = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
+++ b/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
@@ -81,12 +81,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -94,14 +109,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -115,6 +130,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
+++ b/fixtures/transformation/rewiringOfSimpleFunctionalComponents/expected.js
@@ -252,6 +252,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -234,6 +234,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -229,6 +229,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -85,6 +85,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -157,6 +165,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -177,6 +191,12 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/switch/expected.js
+++ b/fixtures/transformation/switch/expected.js
@@ -65,12 +65,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -78,14 +93,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -99,6 +114,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -206,6 +206,14 @@ function _reset__(variableName) {
 
   delete rewireData[variableName];
 
+  if (_exports_to_reset__.has(variableName)) {
+    const value = _exports_to_reset__.get(variableName);
+
+    _update_export__(variableName, value);
+
+    _exports_to_reset__.delete(variableName);
+  }
+
   if (Object.keys(rewireData).length == 0) {
     delete _getRewireRegistry__()[_getRewireModuleId__];
   }

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -68,6 +68,14 @@ function _getRewiredData__() {
   return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+  if (!_exports_to_reset__.has(variableName)) {
+    _exports_to_reset__.set(variableName, value);
+  }
+}
+
 (function registerResetAll() {
   let theGlobalVariable = _getGlobalObject();
 
@@ -134,6 +142,12 @@ function _assign__(variableName, value) {
   let rewireData = _getRewiredData__();
 
   if (rewireData[variableName] === undefined) {
+    var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+    if (isExportedVar && _exports_to_reset__.has(variableName)) {
+      _exports_to_reset__.set(variableName, value);
+    }
+
     return _set_original__(variableName, value);
   } else {
     return rewireData[variableName] = value;
@@ -154,6 +168,12 @@ function _update_operation__(operation, variableName, prefix) {
   _assign__(variableName, newValue);
 
   return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+  switch (variableName) {}
+
+  return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -48,12 +48,27 @@ function _getRewireRegistry__() {
 
   if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
     theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
   }
 
   return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+  const entries = _exports_to_reset__.entries();
+
+  for (const [variableName, value] of entries) {
+    exports[variableName] = value;
+
+    _exports_to_reset__.delete(variableName);
+  }
+}
+
 function _getRewiredData__() {
+  let theGlobalVariable = _getGlobalObject();
+
   let moduleId = _getRewireModuleId__();
 
   let registry = _getRewireRegistry__();
@@ -61,14 +76,14 @@ function _getRewiredData__() {
   let rewireData = registry[moduleId];
 
   if (!rewireData) {
+    const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+    exportsData[moduleId] = _restore_exports__;
     registry[moduleId] = Object.create(null);
     rewireData = registry[moduleId];
   }
 
   return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
   if (!_exports_to_reset__.has(variableName)) {
@@ -82,6 +97,13 @@ function _record_export__(variableName, value) {
   if (!theGlobalVariable['__rewire_reset_all__']) {
     theGlobalVariable['__rewire_reset_all__'] = function () {
       theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+      const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+      for (const restoreFunc of restoreFuncs) {
+        restoreFunc();
+      }
+
+      theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     };
   }
 })();

--- a/fixtures/transformation/topLevelVar/expected.js
+++ b/fixtures/transformation/topLevelVar/expected.js
@@ -211,6 +211,8 @@ function _set__(variableName, value) {
       });
     };
   } else {
+    _update_export__(variableName, value);
+
     if (value === undefined) {
       rewireData[variableName] = INTENTIONAL_UNDEFINED;
     } else {

--- a/fixtures/transformation/track-exports-test/expected.js
+++ b/fixtures/transformation/track-exports-test/expected.js
@@ -272,6 +272,14 @@ function _reset__(variableName) {
 
     delete rewireData[variableName];
 
+    if (_exports_to_reset__.has(variableName)) {
+        const value = _exports_to_reset__.get(variableName);
+
+        _update_export__(variableName, value);
+
+        _exports_to_reset__.delete(variableName);
+    }
+
     if (Object.keys(rewireData).length == 0) {
         delete _getRewireRegistry__()[_getRewireModuleId__];
     }

--- a/fixtures/transformation/track-exports-test/expected.js
+++ b/fixtures/transformation/track-exports-test/expected.js
@@ -1,0 +1,287 @@
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+// Multiple variable declarators test case
+export let a, b, c;
+export let d = '';
+
+let do_not_include = ':(';
+export function e() {
+    // To make sure rewire applies it's transformation
+    // and to test his does't count as a export!
+    _assign__('do_not_include', ':((((');
+}
+
+// To test that identifiers inside the class
+// do not count as identifier
+let do_not_include_class = ':(';
+export class f {
+    constructor() {
+        _assign__('do_not_include_class', ':((((');
+    }
+}
+
+// Export specifier's to test that we don't
+// count local identifier as exported.
+let g_local, h_local, i_local;
+export { g_local as g, h_local as h };
+export { i_local as i };
+
+// Spread operator test. j and k should be
+// recognized as exported.
+const do_not_include_obj = {};
+const _get__2 = _get__('do_not_include_obj'),
+      { j } = _get__2,
+      k = _objectWithoutProperties(_get__2, ['j']);
+
+// Export all should be ignored
+export { j, k };
+export * from '';
+import * as _l from '2';
+export { _l as l };
+
+
+export { m, n, o } from '2';
+export { import1 as p, import2 as q, r } from 'd';
+
+// This will test the function expression, and class expression
+// case.
+export const s = function do_not_include_func() {
+    let do_not_include_2 = ':(';
+},
+      t = function () {
+    let do_not_include_3 = ':(';
+},
+      u = () => {
+    let do_not_include_4 = ':(';
+},
+      v = class DoNotIncludeClass {
+    constructor() {
+        let do_not_include_5 = ':(';
+    }
+},
+      w = class {
+    constructor() {
+        let do_not_include_6 = ':(';
+    }
+};
+
+function _getGlobalObject() {
+    try {
+        if (!!global) {
+            return global;
+        }
+    } catch (e) {
+        try {
+            if (!!window) {
+                return window;
+            }
+        } catch (e) {
+            return this;
+        }
+    }
+}
+
+;
+var _RewireModuleId__ = null;
+
+function _getRewireModuleId__() {
+    if (_RewireModuleId__ === null) {
+        let globalVariable = _getGlobalObject();
+
+        if (!globalVariable.__$$GLOBAL_REWIRE_NEXT_MODULE_ID__) {
+            globalVariable.__$$GLOBAL_REWIRE_NEXT_MODULE_ID__ = 0;
+        }
+
+        _RewireModuleId__ = __$$GLOBAL_REWIRE_NEXT_MODULE_ID__++;
+    }
+
+    return _RewireModuleId__;
+}
+
+function _getRewireRegistry__() {
+    let theGlobalVariable = _getGlobalObject();
+
+    if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
+        theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+    }
+
+    return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
+}
+
+function _getRewiredData__() {
+    let moduleId = _getRewireModuleId__();
+
+    let registry = _getRewireRegistry__();
+
+    let rewireData = registry[moduleId];
+
+    if (!rewireData) {
+        registry[moduleId] = Object.create(null);
+        rewireData = registry[moduleId];
+    }
+
+    return rewireData;
+}
+
+(function registerResetAll() {
+    let theGlobalVariable = _getGlobalObject();
+
+    if (!theGlobalVariable['__rewire_reset_all__']) {
+        theGlobalVariable['__rewire_reset_all__'] = function () {
+            theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+        };
+    }
+})();
+
+var INTENTIONAL_UNDEFINED = '__INTENTIONAL_UNDEFINED__';
+let _RewireAPI__ = {};
+
+(function () {
+    function addPropertyToAPIObject(name, value) {
+        Object.defineProperty(_RewireAPI__, name, {
+            value: value,
+            enumerable: false,
+            configurable: true
+        });
+    }
+
+    addPropertyToAPIObject('__get__', _get__);
+    addPropertyToAPIObject('__GetDependency__', _get__);
+    addPropertyToAPIObject('__Rewire__', _set__);
+    addPropertyToAPIObject('__set__', _set__);
+    addPropertyToAPIObject('__reset__', _reset__);
+    addPropertyToAPIObject('__ResetDependency__', _reset__);
+    addPropertyToAPIObject('__with__', _with__);
+})();
+
+function _get__(variableName) {
+    let rewireData = _getRewiredData__();
+
+    if (rewireData[variableName] === undefined) {
+        return _get_original__(variableName);
+    } else {
+        var value = rewireData[variableName];
+
+        if (value === INTENTIONAL_UNDEFINED) {
+            return undefined;
+        } else {
+            return value;
+        }
+    }
+}
+
+function _get_original__(variableName) {
+    switch (variableName) {
+        case 'do_not_include':
+            return do_not_include;
+
+        case 'do_not_include_class':
+            return do_not_include_class;
+
+        case 'do_not_include_obj':
+            return do_not_include_obj;
+    }
+
+    return undefined;
+}
+
+function _assign__(variableName, value) {
+    let rewireData = _getRewiredData__();
+
+    if (rewireData[variableName] === undefined) {
+        return _set_original__(variableName, value);
+    } else {
+        return rewireData[variableName] = value;
+    }
+}
+
+function _set_original__(variableName, _value) {
+    switch (variableName) {
+        case 'do_not_include':
+            return do_not_include = _value;
+
+        case 'do_not_include_class':
+            return do_not_include_class = _value;
+    }
+
+    return undefined;
+}
+
+function _update_operation__(operation, variableName, prefix) {
+    var oldValue = _get__(variableName);
+
+    var newValue = operation === '++' ? oldValue + 1 : oldValue - 1;
+
+    _assign__(variableName, newValue);
+
+    return prefix ? newValue : oldValue;
+}
+
+function _set__(variableName, value) {
+    let rewireData = _getRewiredData__();
+
+    if (typeof variableName === 'object') {
+        Object.keys(variableName).forEach(function (name) {
+            rewireData[name] = variableName[name];
+        });
+        return function () {
+            Object.keys(variableName).forEach(function (name) {
+                _reset__(variableName);
+            });
+        };
+    } else {
+        if (value === undefined) {
+            rewireData[variableName] = INTENTIONAL_UNDEFINED;
+        } else {
+            rewireData[variableName] = value;
+        }
+
+        return function () {
+            _reset__(variableName);
+        };
+    }
+}
+
+function _reset__(variableName) {
+    let rewireData = _getRewiredData__();
+
+    delete rewireData[variableName];
+
+    if (Object.keys(rewireData).length == 0) {
+        delete _getRewireRegistry__()[_getRewireModuleId__];
+    }
+
+    ;
+}
+
+function _with__(object) {
+    let rewireData = _getRewiredData__();
+
+    var rewiredVariableNames = Object.keys(object);
+    var previousValues = {};
+
+    function reset() {
+        rewiredVariableNames.forEach(function (variableName) {
+            rewireData[variableName] = previousValues[variableName];
+        });
+    }
+
+    return function (callback) {
+        rewiredVariableNames.forEach(function (variableName) {
+            previousValues[variableName] = rewireData[variableName];
+            rewireData[variableName] = object[variableName];
+        });
+        let result = callback();
+
+        if (!!result && typeof result.then == 'function') {
+            result.then(reset).catch(reset);
+        } else {
+            reset();
+        }
+
+        return result;
+    };
+}
+
+export { _get__ as __get__, _get__ as __GetDependency__, _set__ as __Rewire__, _set__ as __set__, _reset__ as __ResetDependency__, _RewireAPI__ as __RewireAPI__ };
+export default _RewireAPI__;

--- a/fixtures/transformation/track-exports-test/expected.js
+++ b/fixtures/transformation/track-exports-test/expected.js
@@ -123,6 +123,14 @@ function _getRewiredData__() {
     return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+    if (!_exports_to_reset__.has(variableName)) {
+        _exports_to_reset__.set(variableName, value);
+    }
+}
+
 (function registerResetAll() {
     let theGlobalVariable = _getGlobalObject();
 
@@ -189,6 +197,12 @@ function _assign__(variableName, value) {
     let rewireData = _getRewiredData__();
 
     if (rewireData[variableName] === undefined) {
+        var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+        if (isExportedVar && _exports_to_reset__.has(variableName)) {
+            _exports_to_reset__.set(variableName, value);
+        }
+
         return _set_original__(variableName, value);
     } else {
         return rewireData[variableName] = value;
@@ -215,6 +229,17 @@ function _update_operation__(operation, variableName, prefix) {
     _assign__(variableName, newValue);
 
     return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+    switch (variableName) {
+        case 'e':
+            _record_export__('e', e);
+
+            return exports.e = _value;
+    }
+
+    return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/track-exports-test/expected.js
+++ b/fixtures/transformation/track-exports-test/expected.js
@@ -103,12 +103,27 @@ function _getRewireRegistry__() {
 
     if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
         theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+        theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
     }
 
     return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+    const entries = _exports_to_reset__.entries();
+
+    for (const [variableName, value] of entries) {
+        exports[variableName] = value;
+
+        _exports_to_reset__.delete(variableName);
+    }
+}
+
 function _getRewiredData__() {
+    let theGlobalVariable = _getGlobalObject();
+
     let moduleId = _getRewireModuleId__();
 
     let registry = _getRewireRegistry__();
@@ -116,14 +131,14 @@ function _getRewiredData__() {
     let rewireData = registry[moduleId];
 
     if (!rewireData) {
+        const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+        exportsData[moduleId] = _restore_exports__;
         registry[moduleId] = Object.create(null);
         rewireData = registry[moduleId];
     }
 
     return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
     if (!_exports_to_reset__.has(variableName)) {
@@ -137,6 +152,13 @@ function _record_export__(variableName, value) {
     if (!theGlobalVariable['__rewire_reset_all__']) {
         theGlobalVariable['__rewire_reset_all__'] = function () {
             theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+            const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+            for (const restoreFunc of restoreFuncs) {
+                restoreFunc();
+            }
+
+            theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
         };
     }
 })();

--- a/fixtures/transformation/track-exports-test/expected.js
+++ b/fixtures/transformation/track-exports-test/expected.js
@@ -277,6 +277,8 @@ function _set__(variableName, value) {
             });
         };
     } else {
+        _update_export__(variableName, value);
+
         if (value === undefined) {
             rewireData[variableName] = INTENTIONAL_UNDEFINED;
         } else {

--- a/fixtures/transformation/track-exports-test/input.js
+++ b/fixtures/transformation/track-exports-test/input.js
@@ -1,0 +1,55 @@
+// Multiple variable declarators test case
+export let a, b, c;
+export let d = '';
+
+let do_not_include = ':(';
+export function e () {
+    // To make sure rewire applies it's transformation
+    // and to test his does't count as a export!
+    do_not_include = ':((((';
+}
+
+// To test that identifiers inside the class
+// do not count as identifier
+let do_not_include_class = ':(';
+export class f {
+    constructor() {
+        do_not_include_class = ':((((';
+    }
+}
+
+// Export specifier's to test that we don't
+// count local identifier as exported.
+let g_local, h_local, i_local;
+export { g_local as g, h_local as h };
+export { i_local as i };
+
+// Spread operator test. j and k should be
+// recognized as exported.
+const do_not_include_obj = {};
+export const { j, ...k } = do_not_include_obj;
+
+// Export all should be ignored
+export * from '';
+export * as l from '2';
+
+export { m, n, o } from '2';
+export { import1 as p, import2 as q, r } from 'd';
+
+// This will test the function expression, and class expression
+// case.
+export const s = function do_not_include_func() {
+    let do_not_include_2 = ':(';
+}, t = function () {
+    let do_not_include_3 = ':('
+}, u = () => {
+    let do_not_include_4 = ':(';
+}, v = class DoNotIncludeClass {
+    constructor() {
+        let do_not_include_5 = ':(';
+    }
+}, w = class {
+    constructor() {
+        let do_not_include_6 = ':(';
+    }
+}

--- a/fixtures/transformation/updateOperations/expected.js
+++ b/fixtures/transformation/updateOperations/expected.js
@@ -77,6 +77,14 @@ function _getRewiredData__() {
 	return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+	if (!_exports_to_reset__.has(variableName)) {
+		_exports_to_reset__.set(variableName, value);
+	}
+}
+
 (function registerResetAll() {
 	let theGlobalVariable = _getGlobalObject();
 
@@ -146,6 +154,12 @@ function _assign__(variableName, value) {
 	let rewireData = _getRewiredData__();
 
 	if (rewireData[variableName] === undefined) {
+		var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+		if (isExportedVar && _exports_to_reset__.has(variableName)) {
+			_exports_to_reset__.set(variableName, value);
+		}
+
 		return _set_original__(variableName, value);
 	} else {
 		return rewireData[variableName] = value;
@@ -178,6 +192,32 @@ function _update_operation__(operation, variableName, prefix) {
 	_assign__(variableName, newValue);
 
 	return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+	switch (variableName) {
+		case "preIncrement":
+			_record_export__("preIncrement", preIncrement);
+
+			return exports.preIncrement = _value;
+
+		case "postIncrement":
+			_record_export__("postIncrement", postIncrement);
+
+			return exports.postIncrement = _value;
+
+		case "preDecrement":
+			_record_export__("preDecrement", preDecrement);
+
+			return exports.preDecrement = _value;
+
+		case "postDecrement":
+			_record_export__("postDecrement", postDecrement);
+
+			return exports.postDecrement = _value;
+	}
+
+	return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/updateOperations/expected.js
+++ b/fixtures/transformation/updateOperations/expected.js
@@ -57,12 +57,27 @@ function _getRewireRegistry__() {
 
 	if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 		theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+		theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 	}
 
 	return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+	const entries = _exports_to_reset__.entries();
+
+	for (const [variableName, value] of entries) {
+		exports[variableName] = value;
+
+		_exports_to_reset__.delete(variableName);
+	}
+}
+
 function _getRewiredData__() {
+	let theGlobalVariable = _getGlobalObject();
+
 	let moduleId = _getRewireModuleId__();
 
 	let registry = _getRewireRegistry__();
@@ -70,14 +85,14 @@ function _getRewiredData__() {
 	let rewireData = registry[moduleId];
 
 	if (!rewireData) {
+		const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+		exportsData[moduleId] = _restore_exports__;
 		registry[moduleId] = Object.create(null);
 		rewireData = registry[moduleId];
 	}
 
 	return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 	if (!_exports_to_reset__.has(variableName)) {
@@ -91,6 +106,13 @@ function _record_export__(variableName, value) {
 	if (!theGlobalVariable['__rewire_reset_all__']) {
 		theGlobalVariable['__rewire_reset_all__'] = function () {
 			theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+			const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+			for (const restoreFunc of restoreFuncs) {
+				restoreFunc();
+			}
+
+			theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		};
 	}
 })();

--- a/fixtures/transformation/updateOperations/expected.js
+++ b/fixtures/transformation/updateOperations/expected.js
@@ -255,6 +255,8 @@ function _set__(variableName, value) {
 			});
 		};
 	} else {
+		_update_export__(variableName, value);
+
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED;
 		} else {

--- a/fixtures/transformation/updateOperations/expected.js
+++ b/fixtures/transformation/updateOperations/expected.js
@@ -250,6 +250,14 @@ function _reset__(variableName) {
 
 	delete rewireData[variableName];
 
+	if (_exports_to_reset__.has(variableName)) {
+		const value = _exports_to_reset__.get(variableName);
+
+		_update_export__(variableName, value);
+
+		_exports_to_reset__.delete(variableName);
+	}
+
 	if (Object.keys(rewireData).length == 0) {
 		delete _getRewireRegistry__()[_getRewireModuleId__];
 	}

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -68,6 +68,14 @@ function _getRewiredData__() {
 		return rewireData;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _record_export__(variableName, value) {
+		if (!_exports_to_reset__.has(variableName)) {
+				_exports_to_reset__.set(variableName, value);
+		}
+}
+
 (function registerResetAll() {
 		let theGlobalVariable = _getGlobalObject();
 
@@ -137,6 +145,12 @@ function _assign__(variableName, value) {
 		let rewireData = _getRewiredData__();
 
 		if (rewireData[variableName] === undefined) {
+				var isExportedVar = Object.prototype.hasOwnProperty.call(exports, variableName);
+
+				if (isExportedVar && _exports_to_reset__.has(variableName)) {
+						_exports_to_reset__.set(variableName, value);
+				}
+
 				return _set_original__(variableName, value);
 		} else {
 				return rewireData[variableName] = value;
@@ -157,6 +171,12 @@ function _update_operation__(operation, variableName, prefix) {
 		_assign__(variableName, newValue);
 
 		return prefix ? newValue : oldValue;
+}
+
+function _update_export__(variableName, _value) {
+		switch (variableName) {}
+
+		return undefined;
 }
 
 function _set__(variableName, value) {

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -209,6 +209,14 @@ function _reset__(variableName) {
 
 		delete rewireData[variableName];
 
+		if (_exports_to_reset__.has(variableName)) {
+				const value = _exports_to_reset__.get(variableName);
+
+				_update_export__(variableName, value);
+
+				_exports_to_reset__.delete(variableName);
+		}
+
 		if (Object.keys(rewireData).length == 0) {
 				delete _getRewireRegistry__()[_getRewireModuleId__];
 		}

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -214,6 +214,8 @@ function _set__(variableName, value) {
 						});
 				};
 		} else {
+				_update_export__(variableName, value);
+
 				if (value === undefined) {
 						rewireData[variableName] = INTENTIONAL_UNDEFINED;
 				} else {

--- a/fixtures/transformation/wildcardImport/expected.js
+++ b/fixtures/transformation/wildcardImport/expected.js
@@ -48,12 +48,27 @@ function _getRewireRegistry__() {
 
 		if (!theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__) {
 				theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+				theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 		}
 
 		return theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__;
 }
 
+const _exports_to_reset__ = new Map();
+
+function _restore_exports__() {
+		const entries = _exports_to_reset__.entries();
+
+		for (const [variableName, value] of entries) {
+				exports[variableName] = value;
+
+				_exports_to_reset__.delete(variableName);
+		}
+}
+
 function _getRewiredData__() {
+		let theGlobalVariable = _getGlobalObject();
+
 		let moduleId = _getRewireModuleId__();
 
 		let registry = _getRewireRegistry__();
@@ -61,14 +76,14 @@ function _getRewiredData__() {
 		let rewireData = registry[moduleId];
 
 		if (!rewireData) {
+				const exportsData = theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__;
+				exportsData[moduleId] = _restore_exports__;
 				registry[moduleId] = Object.create(null);
 				rewireData = registry[moduleId];
 		}
 
 		return rewireData;
 }
-
-const _exports_to_reset__ = new Map();
 
 function _record_export__(variableName, value) {
 		if (!_exports_to_reset__.has(variableName)) {
@@ -82,6 +97,13 @@ function _record_export__(variableName, value) {
 		if (!theGlobalVariable['__rewire_reset_all__']) {
 				theGlobalVariable['__rewire_reset_all__'] = function () {
 						theGlobalVariable.__$$GLOBAL_REWIRE_REGISTRY__ = Object.create(null);
+						const restoreFuncs = Object.values(theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__);
+
+						for (const restoreFunc of restoreFuncs) {
+								restoreFunc();
+						}
+
+						theGlobalVariable.__$$GLOBAL_REWIRE_EXPORTS_REGISTRY__ = Object.create(null);
 				};
 		}
 })();

--- a/samples/ExportsSyncsWithInternalState/sample.js
+++ b/samples/ExportsSyncsWithInternalState/sample.js
@@ -1,0 +1,53 @@
+import { strict as assert } from 'assert';
+import { a, __RewireAPI__ as ARewireAPI } from './src/a';
+import { b, __RewireAPI__ as BRewireAPI } from './src/b';
+import { main, __RewireAPI__ as MainRewireAPI } from './src/main';
+
+describe('ExportsSyncsWithInternalState', () => {
+    function ensureOriginalState() {
+        assert.equal(a(), 'a');
+        assert.equal(b(), 'a-b');
+        assert.equal(main(), 'a-b-main');
+    }
+
+    it('should sync exports with internal state', () => {
+        // Test that rewiring a on module a updates, both the
+        // internal and exports state and it reflects across other
+        // modules.
+        ARewireAPI.__Rewire__('a', () => 'rewire-a');
+        assert.equal(ARewireAPI.__get__('a')(), 'rewire-a');
+        assert.equal(a(), 'rewire-a');
+        assert.equal(b(), 'rewire-a-b')
+        assert.equal(main(), 'rewire-a-b-main');
+    });
+
+    it('should restore the exports when calling __reset__', () => {
+        // Reset should restore it to original state.
+        ARewireAPI.__ResetDependency__('a');
+        ensureOriginalState();
+
+        // Also test that calling rewire more than once does
+        // cause wrong restore value to be store in the Map.
+        ARewireAPI.__Rewire__('a', () => 'rewire-1-a');
+        ARewireAPI.__Rewire__('a', () => 'rewire-2-a');
+        assert.equal(a(), 'rewire-2-a');
+        assert.equal(b(), 'rewire-2-a-b');
+        assert.equal(main(), 'rewire-2-a-b-main');
+
+        ARewireAPI.__ResetDependency__('a');
+        ensureOriginalState();
+    });
+
+    it('should restore all modules export state to original correctly', () => {
+        ARewireAPI.__Rewire__('a', () => 'A');
+        BRewireAPI.__Rewire__('b', () => 'B');
+        MainRewireAPI.__Rewire__('main', () => 'MAIN');
+        assert.equal(a(), 'A');
+        assert.equal(b(), 'B');
+        assert.equal(main(), 'MAIN');
+
+        __rewire_reset_all__();
+        ensureOriginalState();
+    });
+});
+

--- a/samples/ExportsSyncsWithInternalState/src/a.js
+++ b/samples/ExportsSyncsWithInternalState/src/a.js
@@ -1,0 +1,6 @@
+// We use the value variable here so the function
+// a() is rewireable.
+const value = 'a';
+export function a() {
+    return value;
+}

--- a/samples/ExportsSyncsWithInternalState/src/b.js
+++ b/samples/ExportsSyncsWithInternalState/src/b.js
@@ -1,0 +1,5 @@
+import { a } from './a';
+
+export function b() {
+    return a() + '-b';
+}

--- a/samples/ExportsSyncsWithInternalState/src/main.js
+++ b/samples/ExportsSyncsWithInternalState/src/main.js
@@ -1,0 +1,9 @@
+/**
+ * This module depends on modula b, and module a indirectly.
+ */
+
+import { b } from './b';
+
+export function main() {
+    return b() + '-main';
+}

--- a/src/RewireState.js
+++ b/src/RewireState.js
@@ -50,6 +50,7 @@ export default class RewireState {
 		this.updateOriginalExportIdentifier = scope.generateUidIdentifier('__update_export__');
 		this.originalExportsToResetIdentifier = scope.generateUidIdentifier('__exports_to_reset__');
 		this.recordOriginalExportIdentifier = scope.generateUidIdentifier('__record_export__');
+		this.restoreExportsIdentifier = scope.generateUidIdentifier('__restore_exports__');
 
 		// Tracks all the variables that are being exported.
 		// Key is the exported identifier while key is exported identifier.
@@ -186,6 +187,7 @@ export default class RewireState {
 			UPDATE_ORIGINAL_EXPORT_IDENTIFIER: this.updateOriginalExportIdentifier,
 			ORIGINAL_EXPORTS_TO_RESET_IDENTIFIER: this.originalExportsToResetIdentifier,
 			RECORD_ORIGINAL_EXPORT_IDENTIFIER: this.recordOriginalExportIdentifier,
+			RESTORE_EXPORTS_IDENTIFIER: this.restoreExportsIdentifier,
 			UNIVERSAL_GETTER_ID :this.getUniversalGetterID(),
 			UNIVERSAL_SETTER_ID :this.getUniversalSetterID(),
 			UNIVERSAL_RESETTER_ID :this.getUniversalResetterID(),

--- a/src/RewireState.js
+++ b/src/RewireState.js
@@ -48,6 +48,10 @@ export default class RewireState {
 		this.assignmentOperationIdentifier = scope.generateUidIdentifier('__assign__');
 		this.typeofOriginalExportVariable = scope.generateUidIdentifier('typeOfOriginalExport');
 
+		// Tracks all the variables that are being exported.
+		// Key is the exported identifier while key is exported identifier.
+		this.exportedIdentifiers = new Map();
+
 		this.universalAccessors = {
 			__get__: noRewire(scope.generateUidIdentifier('__get__')),
 			__set__: noRewire(scope.generateUidIdentifier('__set__')),
@@ -80,7 +84,11 @@ export default class RewireState {
 
 		return this.accessors[variableName];
 	}
-	
+
+	addExportedIdentifier(exportedIdentifier, localIdentifier) {
+		this.exportedIdentifiers.set(exportedIdentifier, localIdentifier);
+	}
+
 	addTrackedIdentifier(variableName, isWildcardImport = false) {
 		this.isWildcardImport[variableName] = isWildcardImport
 		return this.trackedIdentfiers[variableName] = true;

--- a/src/Templates.js
+++ b/src/Templates.js
@@ -176,6 +176,13 @@ function UNIVERSAL_SETTER_ID(variableName, value) {
 function UNIVERSAL_RESETTER_ID(variableName) {
 	let rewireData = GET_REWIRE_DATA_IDENTIFIER();
 	delete rewireData[variableName];
+
+	if (ORIGINAL_EXPORTS_TO_RESET_IDENTIFIER.has(variableName)) {
+		const value = ORIGINAL_EXPORTS_TO_RESET_IDENTIFIER.get(variableName);
+		UPDATE_ORIGINAL_EXPORT_IDENTIFIER(variableName, value);
+		ORIGINAL_EXPORTS_TO_RESET_IDENTIFIER.delete(variableName);
+	}
+
 	if(Object.keys(rewireData).length == 0) {
 		delete GET_REWIRE_REGISTRY_IDENTIFIER()[GET_UNIQUE_GLOBAL_MODULE_ID_IDENTIFIER];
 	};

--- a/src/Templates.js
+++ b/src/Templates.js
@@ -185,6 +185,7 @@ function UNIVERSAL_SETTER_ID(variableName, value) {
 			});
 		}
 	} else {
+		UPDATE_ORIGINAL_EXPORT_IDENTIFIER(variableName, value);
 		if (value === undefined) {
 			rewireData[variableName] = INTENTIONAL_UNDEFINED
 		} else {

--- a/test/BabelRewirePluginTransformTest.js
+++ b/test/BabelRewirePluginTransformTest.js
@@ -14,7 +14,8 @@ describe('BabelRewirePluginTest', function() {
 			babelPluginRewire,
 			"syntax-async-functions",
 			"syntax-flow",
-			"transform-export-extensions"
+			"transform-export-extensions",
+			"transform-object-rest-spread",
 		]
 	};
 
@@ -26,7 +27,8 @@ describe('BabelRewirePluginTest', function() {
 			}],
 			"syntax-async-functions",
 			"syntax-flow",
-			"transform-export-extensions"
+			"transform-export-extensions",
+			"transform-object-rest-spread",
 		]
 	};
 
@@ -40,7 +42,8 @@ describe('BabelRewirePluginTest', function() {
 			"transform-es2015-template-literals",
 			"transform-es2015-typeof-symbol",
 			"transform-export-extensions",
-			"transform-regenerator"
+			"transform-regenerator",
+			"transform-object-rest-spread",
 		]
 	};
 
@@ -66,6 +69,7 @@ describe('BabelRewirePluginTest', function() {
 		}
 
 		var tempDir = path.resolve(os.tmpdir(), 'babel-plugin-rewire');
+		// console.log('TempDir: ' + tempDir);
 		try {
 			fs.mkdirSync(tempDir);
 		} catch(error) {}
@@ -152,7 +156,8 @@ describe('BabelRewirePluginTest', function() {
 		'issue136',
 		'issue152',
 		'issue155',
-		'issue184'
+		'issue184',
+		'track-exports-test',
 	];
 
 	var stage0FeaturesToTests = [

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -79,7 +79,8 @@ var configurations = {
 			'issue163',
 			'issue165',
 			'issue109',
-			'issue184'
+			'issue184',
+			'ExportsSyncsWithInternalState',
 		]
 	},
 	transformSampleCodeToTestWithBabelPluginRewireAndTransformAsyncToGenerator: {


### PR DESCRIPTION
For this test code code:
```typescript
// a.ts
export function a() {
  return status;
}

// b.ts
import { a} from './a';
export function someFunc() {
  if (a()) {
     // ...
  }
}
```

When testing the the `b` module, you can rewire an export on a by calling `b.__Rewire__(a, <export-name>, ...)` this PR makes it so, calling `a.__Rewire(<export-name>, ...)` also updates not just the internal namespace but exports too. So the call to exported function `a` in module `b` is rewired. This is super useful when we have tons of modules that are used in the module we are testing. And, `__ResetDependency__` and `__rewire_reset_all` also reset the exports updated via `__Rewire__`.

cc @rosswarren. 