### PR TITLE
rewire-ts: Register declarations we add manually to scope tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ $ npm install babel-core babel-plugin-rewire
 
 ## Usage
 
-To use the plugin identify it by its long name "babel-plugin-rewire" or by its abbreviation "rewire". In case you are using rewire.js in the same project you must use the unabbreviated plugin name. Otherwise babel is trying to load rewire.js as a plugin which will cause an [error](https://github.com/speedskater/babel-plugin-rewire/issues/5).
+To use the plugin identify it by its long name "babel-plugin-rewire-ts" or by its abbreviation
+"rewire-ts".
 
 ### Commandline
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,20 @@ $ npm install babel-core babel-plugin-rewire
 To use the plugin identify it by its long name "babel-plugin-rewire-ts" or by its abbreviation
 "rewire-ts".
 
+If you are using `@babel/plugin-tranform-typescript` and encounter these warnings:
+```
+The exported identifier "_get__" is not declared in Babel's scope tracker
+as a JavaScript value binding, and "@babel/plugin-transform-typescript"
+never encountered it as a TypeScript type declaration.
+It will be treated as a JavaScript value.
+...
+```
+
+We recommend you switch to `@babel/preset-typescript`, since it type-checks
+your code while the plugin does not. Or use `@babel/preset-env` along with
+the plugin to resolve those warnings. We already fixed the issue on our side
+and reason behind those warning is unclear and they are harmless.
+
 ### Commandline
 
 abbreviated:


### PR DESCRIPTION
This resolves and issue where babel-plugin-transform-typescript
throws warning stating the declaration we added via path.replace
and path.replaceWithMultiple.

Fixes: #5, #6 
